### PR TITLE
Install of vision dependencies

### DIFF
--- a/master.yml
+++ b/master.yml
@@ -3,7 +3,7 @@
 - import_playbook: playbooks/deactivate_password_playbook.yml
 - import_playbook: playbooks/enable_camera_playbook.yml
 - import_playbook: playbooks/common_playbook.yml
-- import_playbook: install_vision_dependencies.yml
+- import_playbook: playbooks/install_vision_dependencies.yml
 - import_playbook: playbooks/run_scripts_camera_playbook.yml
 - import_playbook: playbooks/stop_service_playbook.yml
   vars:

--- a/master.yml
+++ b/master.yml
@@ -3,6 +3,7 @@
 - import_playbook: playbooks/deactivate_password_playbook.yml
 - import_playbook: playbooks/enable_camera_playbook.yml
 - import_playbook: playbooks/common_playbook.yml
+- import_playbook: install_vision_dependencies.yml
 - import_playbook: playbooks/run_scripts_camera_playbook.yml
 - import_playbook: playbooks/stop_service_playbook.yml
   vars:

--- a/playbooks/install_vision_dependencies.yml
+++ b/playbooks/install_vision_dependencies.yml
@@ -3,7 +3,7 @@
   hosts: raspberry
 
   pre_tasks:
-    - name: install some dependecies
+    - name: install dependecies needed for pyro-vision module
       apt:
         name:
           - libopenblas-dev

--- a/playbooks/install_vision_dependencies.yml
+++ b/playbooks/install_vision_dependencies.yml
@@ -1,0 +1,26 @@
+---
+- name: pyro-vision dependecies
+  hosts: testing_raspberry
+
+  pre_tasks:
+    - name: install some dependecies
+      apt:
+        name:
+          - libopenblas-dev
+          - libopenjp2-7
+          - libtiff5
+        state: latest
+        update_cache: yes
+      become: true
+      register: apt_output
+      tags: always
+
+    - name: install pytorch 
+      pip:
+        name: https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torch-1.7.0a0-cp37-cp37m-linux_armv7l.whl
+      tags: always
+
+    - name: install torchvision
+      pip:
+        name: https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torchvision-0.8.0-cp37-cp37m-linux_armv7l.whl
+      tags: always

--- a/playbooks/install_vision_dependencies.yml
+++ b/playbooks/install_vision_dependencies.yml
@@ -15,7 +15,7 @@
       register: apt_output
       tags: always
 
-    - name: install pytorch 
+    - name: install pytorch
       pip:
         name: https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torch-1.7.0a0-cp37-cp37m-linux_armv7l.whl
       tags: always

--- a/playbooks/install_vision_dependencies.yml
+++ b/playbooks/install_vision_dependencies.yml
@@ -10,7 +10,7 @@
           - libopenjp2-7
           - libtiff5
         state: latest
-        update_cache: yes
+        update_cache: true
       become: true
       register: apt_output
       tags: always

--- a/playbooks/install_vision_dependencies.yml
+++ b/playbooks/install_vision_dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: pyro-vision dependecies
-  hosts: testing_raspberry
+  hosts: raspberry
 
   pre_tasks:
     - name: install some dependecies


### PR DESCRIPTION
## Feature

This PR add playbook to install vision dependencies for raspberry set up

## Motivation

As central pi will performed inference, it relies on packages required in [pyro-vision](https://github.com/pyronear/pyro-vision)

Following issue pyronear/pyro-vision#113, versions of pytorch and torchvision packages compiled for ARM processor are available in the release V0.1.1 of pyro-vison

Those package needs to be installed at set up on central pi.

Hence, the following PR introduces a playbook that initiate pyro-vision dependences.


So far, version of package is hardcoded in the url. We could consider add variable and especially get the latest version of packages from the latest release of pyro-vision (via https://api.github.com ). However, it might introduce less stability.

Also, I was hesitating where I should create a dedicated role and add it to common_playbooks or creating a dedicated playbook and import it in the master playbook.

Any feedback are welcomed 