### PR TITLE
Small refacto

### DIFF
--- a/host_vars/hosts.yml
+++ b/host_vars/hosts.yml
@@ -16,3 +16,7 @@ raspberry:
 raspberry_with_camera:
   hosts:
     rasp2:
+
+raspberry_masters:
+  hosts:
+    rasp3:

--- a/master.yml
+++ b/master.yml
@@ -4,6 +4,7 @@
 - import_playbook: playbooks/enable_camera_playbook.yml
 - import_playbook: playbooks/common_playbook.yml
 - import_playbook: playbooks/install_vision_dependencies.yml
+- import_playbook: playbooks/install_local_api_dependencies.yaml
 - import_playbook: playbooks/run_scripts_camera_playbook.yml
 - import_playbook: playbooks/stop_service_playbook.yml
   vars:

--- a/master.yml
+++ b/master.yml
@@ -4,7 +4,7 @@
 - import_playbook: playbooks/enable_camera_playbook.yml
 - import_playbook: playbooks/common_playbook.yml
 - import_playbook: playbooks/install_vision_dependencies.yml
-- import_playbook: playbooks/install_local_api_dependencies.yaml
+- import_playbook: playbooks/install_local_api_dependencies.yml
 - import_playbook: playbooks/run_scripts_camera_playbook.yml
 - import_playbook: playbooks/stop_service_playbook.yml
   vars:

--- a/playbooks/common_playbook.yml
+++ b/playbooks/common_playbook.yml
@@ -31,14 +31,15 @@
       become: true
       tags: dangerous
 
-  roles:
-    - role: geerlingguy.docker_arm
-      become: true
-      tags: docker
-
   tasks:
     - name: create folder to store images
       file:
         path: /home/pi/images
         state: directory
-      tags: example
+      tags: python_script
+
+    - name: create folder to store python scripts
+      file:
+        path: /home/pi/python_scripts
+        state: directory
+      tags: python_script

--- a/playbooks/install_local_api_dependencies.yml
+++ b/playbooks/install_local_api_dependencies.yml
@@ -1,0 +1,8 @@
+---
+- name: local-api dependecies
+  hosts: raspberry_masters
+
+  roles:
+    - role: geerlingguy.docker_arm
+      become: true
+      tags: docker

--- a/playbooks/install_vision_dependencies.yml
+++ b/playbooks/install_vision_dependencies.yml
@@ -2,28 +2,24 @@
 - name: pyro-vision dependecies
   hosts: raspberry_masters
 
-  pre_tasks:
-    - name: install dependecies needed for pyro-vision module
-      apt:
-        name:
-          - libopenblas-dev
-          - libopenjp2-7
-          - libtiff5
-        state: latest
-        update_cache: true
-      become: true
-      register: apt_output
-      tags: always
+  tasks:
+  - name: install dependecies needed for pyro-vision module
+    apt:
+      name:
+        - libopenblas-dev
+        - libopenjp2-7
+        - libtiff5
+      state: latest
+      update_cache: true
+    become: true
+    register: apt_output
+    tags: always
 
-    - name: install pytorch & create venv
-      pip:
-        name: https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torch-1.7.0a0-cp37-cp37m-linux_armv7l.whl
-        virtualenv: /home/pi/python_scripts/venv
-        virtualenv_command: python3 -m venv
-      tags: always
-
-    - name: install torchvision
-      pip:
-        name: https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torchvision-0.8.0-cp37-cp37m-linux_armv7l.whl
-        virtualenv: /home/pi/python_scripts/venv
-      tags: always
+  - name: install pytorch, torchvision & create venv
+    pip:
+      name:
+        - https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torch-1.7.0a0-cp37-cp37m-linux_armv7l.whl
+        - https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torchvision-0.8.0-cp37-cp37m-linux_armv7l.whl
+      virtualenv: /home/pi/python_scripts/venv
+      virtualenv_command: python3 -m venv
+    tags: always

--- a/playbooks/install_vision_dependencies.yml
+++ b/playbooks/install_vision_dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: pyro-vision dependecies
-  hosts: raspberry
+  hosts: raspberry_masters
 
   pre_tasks:
     - name: install dependecies needed for pyro-vision module
@@ -15,12 +15,15 @@
       register: apt_output
       tags: always
 
-    - name: install pytorch
+    - name: install pytorch & create venv
       pip:
         name: https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torch-1.7.0a0-cp37-cp37m-linux_armv7l.whl
+        virtualenv: /home/pi/python_scripts/venv
+        virtualenv_command: python3 -m venv
       tags: always
 
     - name: install torchvision
       pip:
         name: https://github.com/pyronear/pyro-vision/releases/download/v0.1.1/torchvision-0.8.0-cp37-cp37m-linux_armv7l.whl
+        virtualenv: /home/pi/python_scripts/venv
       tags: always

--- a/playbooks/run_scripts_camera_playbook.yml
+++ b/playbooks/run_scripts_camera_playbook.yml
@@ -3,23 +3,17 @@
   hosts: raspberry_with_camera
 
   tasks:
-    - name: create folder to store example scripts
-      file:
-        path: /home/pi/example_scripts
-        state: directory
-      tags: example
-
     - name: copy rpi.requirements.txt
       ansible.builtin.copy:
         src: ../rpi.requirements.txt
-        dest: /home/pi/example_scripts/rpi.requirements.txt
-      tags: example
+        dest: /home/pi/python_scripts/rpi.requirements.txt
+      tags: python_script
 
     - name: copy .env file & python script to be executed later on hosts
       ansible.builtin.copy:
         src: "{{ item.src }}"
-        dest: "/home/pi/example_scripts/{{ item.dest }}"
-      tags: example
+        dest: "/home/pi/python_scripts/{{ item.dest }}"
+      tags: python_script
       with_items:
         - src: ../.env
           dest: .env
@@ -28,13 +22,12 @@
 
     - name: install rpi.requirements.txt & create venv
       pip:
-        requirements: /home/pi/example_scripts/rpi.requirements.txt
-        virtualenv: /home/pi/example_scripts/venv
-        virtualenv_command: python3 -m venv
-      tags: example
+        requirements: /home/pi/python_scripts/rpi.requirements.txt
+        virtualenv: /home/pi/python_scripts/venv
+      tags: python_script
 
     - name: run script take_picture.py
       ansible.builtin.command:
-        cmd: /home/pi/example_scripts/venv/bin/python3 take_picture.py
-        chdir: /home/pi/example_scripts/
-      tags: example
+        cmd: /home/pi/python_scripts/venv/bin/python3 take_picture.py
+        chdir: /home/pi/python_scripts/
+      tags: python_script

--- a/playbooks/run_scripts_camera_playbook.yml
+++ b/playbooks/run_scripts_camera_playbook.yml
@@ -24,6 +24,7 @@
       pip:
         requirements: /home/pi/python_scripts/rpi.requirements.txt
         virtualenv: /home/pi/python_scripts/venv
+        virtualenv_command: python3 -m venv
       tags: python_script
 
     - name: run script take_picture.py

--- a/playbooks/stop_service_playbook.yml
+++ b/playbooks/stop_service_playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: stop service
-  hosts: raspberry
+  hosts: raspberry_masters
 
   tasks:
     - name: stop service


### PR DESCRIPTION
Hi all ! This PR aims at:

- adding a sub-type of hosts: `raspberry_masters` (i.e. the main ones)
- install vision dep only on `raspberry_masters` and install python packages in a venv (chich, as of now, is in a folder named `python_scripts`: the folder might be renamed afterwords to fit the needs we shall have)
- this venv will be used to install local api dependencies if needed (the use of docker container for the local API has been discussed but still I believe that creating and installing vision dependencies in a venv is cleaner, it avoids many packages conflicts which can arouse). 
- creation of a special playbook to install local api dependencies: the docker role has been moved from `common_playbook` to `install_local_api_dependencies` since the use of docker is specific to the main rpis.

Some of these bullet-points are only temporary fixes for when the local api will be done and ready to go + when we will know what `pyro-engine` will be able to do. We shall iterate when it becomes clearer. 

As always, feeback is welcome 🤗 