### PR TITLE
Rename hosts variable raspberry_mains

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Then, refer to RpiSETUP.md for simple instructions upon flashing your SD Card.
 
 Finally, you need to add a SLACK_WEBHOOK_URL (incoming webhook app) in `vars/main.yml`. To get more information on how to create an incoming webhook app, see this [documentation](https://api.slack.com/tutorials/slack-apps-hello-world).
 
+For instructions regarding the directory `files/ansible_on_main_rpi`, please refer to its `README.md` in the corresponding directory.
+
 ## Use master.yml playbook:
 This is the master playbook, used to setup our fleet of RPI. To run it:
 

--- a/host_vars/hosts.yml
+++ b/host_vars/hosts.yml
@@ -17,6 +17,6 @@ raspberry_with_camera:
   hosts:
     rasp2:
 
-raspberry_masters:
+raspberry_mains:
   hosts:
     rasp3:

--- a/playbooks/add_jobs_crontab.yml
+++ b/playbooks/add_jobs_crontab.yml
@@ -1,6 +1,6 @@
 ---
 - name: put jobs in crontab master rpi
-  hosts: raspberry_masters
+  hosts: raspberry_mains
 
   tasks:
     - name: add monitor_pi.py script to crontab to be launched on reboot

--- a/playbooks/install_ansible_rpi_main.yml
+++ b/playbooks/install_ansible_rpi_main.yml
@@ -1,6 +1,6 @@
 ---
 - name: setup ansible usage and tasks on main rpi
-  hosts: raspberry_masters
+  hosts: raspberry_mains
 
   tasks:
     - name: Include vars

--- a/playbooks/install_local_api_dependencies.yml
+++ b/playbooks/install_local_api_dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: local-api dependecies and build
-  hosts: raspberry_masters
+  hosts: raspberry_mains
 
   roles:
     - role: geerlingguy.docker_arm

--- a/playbooks/install_pyroengine.yml
+++ b/playbooks/install_pyroengine.yml
@@ -1,6 +1,6 @@
 ---
 - name: install core repositories on rpi master
-  hosts: raspberry_masters
+  hosts: raspberry_mains
 
   tasks:
     - name: Clone pyro-engine

--- a/playbooks/install_vision_dependencies.yml
+++ b/playbooks/install_vision_dependencies.yml
@@ -1,6 +1,6 @@
 ---
 - name: pyro-vision dependecies
-  hosts: raspberry_masters
+  hosts: raspberry_mains
 
   tasks:
     - name: install dependecies needed for pyro-vision module

--- a/playbooks/stop_service_playbook.yml
+++ b/playbooks/stop_service_playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: stop service
-  hosts: raspberry_masters
+  hosts: raspberry_mains
 
   tasks:
     - name: stop service


### PR DESCRIPTION
Hello everyone ! 

Quick PR to rename `raspberry_masters` to `raspberry_mains` and add a file of instruction missing it the README.md.