### PR TITLE
Install vim on all rpi

### DIFF
--- a/playbooks/common_playbook.yml
+++ b/playbooks/common_playbook.yml
@@ -7,10 +7,11 @@
       raw: test -r /usr/bin/python3 || (apt-get update && apt-get install -y python3)
       tags: common_config
 
-    - name: install git, pip3 and python3-venv
+    - name: install git, vim, pip3 and python3-venv
       apt:
         name:
           - git
+          - vim
           - python3-pip
           - python3-venv
         state: latest


### PR DESCRIPTION
Hello everyone, 

## Motivation 

Small PR to install vim on all rpi. I think this could come in-handy as we might need to ssh on the rpi and modify some scripts/files and vim is a pretty nice editor (compared to nano which is already installed on rpi).

If you feel like nano is enough, then fine by me, vim is my personal preference but as you wish, it's only a proposal ! 