### PR TITLE
Add possibily to add on rpi multiple public keys as authorized_keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,19 @@ brew install hudochenkov/sshpass/sshpass
 
 Then, refer to RpiSETUP.md for simple instructions upon flashing your SD Card.
 
-Finally, you need to add a **SLACK_WEBHOOK_URL** (incoming webhook app) in `vars/main.yml`. To get more information on how to create an incoming webhook app, see this [documentation](https://api.slack.com/tutorials/slack-apps-hello-world).
+If you want multiple `id_rsa.pub` keys to be added on all your raspberry pis (other than the public key of the localhost 
+launching the playbooks), you can add the keys in the folder `files/ssh_localhost_keys`.
+These keys will then be added by the role `ssh_role` in the `authorized_keys` of your raspberry pis, allowing you to ssh on them if needed.
+Each public key has to be added in a separate file, for instance:
+- `id_rsa_user1.pub`
+- `id_rsa_user2.pub` \
+And so on. \
+The public key of the local machine that you are using to launch Ansible and the playbooks will be automatically added 
+  by the `ssh_role`, provided that you give the path to your public key in `roles/ssh_role/defaults/main.yml` by changing
+  the variable `public_key_path`.
+
+Finally, you need to add a **SLACK_WEBHOOK_URL** (incoming webhook app) in `vars/main.yml`. 
+To get more information on how to create an incoming webhook app, see this [documentation](https://api.slack.com/tutorials/slack-apps-hello-world).
 
 For instructions regarding the directory `files/ansible_on_main_rpi`, please refer to its `README.md` in the corresponding directory.
 

--- a/roles/ssh_role/tasks/main.yml
+++ b/roles/ssh_role/tasks/main.yml
@@ -10,11 +10,24 @@
     path: ~/.ssh/
     state: directory
 
-- name: Set authorized key on rpi taken from local file
+- name: Set authorized key on rpi taken from localhost file
   ansible.posix.authorized_key:
     user: "{{ ansible_user }}"
     state: present
     key: "{{ lookup('file', public_key_path) }}"
+
+- name: list file in directory
+  ansible.builtin.find:
+    paths: ../files/ssh_localhost_keys
+  register: files_list
+  delegate_to: 127.0.0.1
+
+- name: Set multiple authorized_keys on all rpi from folder files/ssh_localhost_keys
+  ansible.posix.authorized_key:
+    user: "{{ ansible_user }}"
+    state: present
+    key: "{{ lookup('file', item.path ) }}"
+  with_items: "{{ files_list.files }}"
 
 - name: Generated ssh key on rpi
   openssh_keypair:


### PR DESCRIPTION
Hi ! 

As discussed, this PR gives the possibility to add multiple public keys on all the rpi through the role `ssh_role` and by adding the keys in the folder `files/ssh_localhost_keys`.

As always, feedback is welcomed ! 