### PR TITLE
Add role to set hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You need sshpass on your local machine:
 brew install hudochenkov/sshpass/sshpass
 ````
 
-**CAREFUL** You also need to modify `host_vars/hosts.yml` to put your own rpi `ansible_host`, `ansible_user`, `ansible_password` and `ansible_python_interpreter`.
+**CAREFUL** You also need to modify `host_vars/hosts.yml` to put your own rpi `ansible_host`, `ansible_user`, `ansible_password`, `ansible_python_interpreter` and `hostname`.
 
 Then, refer to RpiSETUP.md for simple instructions upon flashing your SD Card.
 

--- a/files/ansible_on_main_rpi/README.md
+++ b/files/ansible_on_main_rpi/README.md
@@ -16,7 +16,7 @@ The layout is the following:
 ```
 
 The `templates/python.env` file must contain:
-- `WEBSERVER_IP`: the IP address of the main rpi once it is installed on site
+- `WEBSERVER_IP`: the dns of the main rpi once it is installed on site (it should correspond to the `hostname` of the main rpi)
 - `WEBSERVER_PORT`: the port exposed on the main rpi for the local webserver
 
 ### Playbooks:

--- a/files/ansible_on_main_rpi/hosts.yml
+++ b/files/ansible_on_main_rpi/hosts.yml
@@ -3,7 +3,7 @@
 raspberry_with_camera:
   hosts:
     rasp2:
-      ansible_host: 192.168.0.24
+      ansible_host: raspcamera1.local
       ansible_user: pi
       ansible_password: raspberry
       ansible_python_interpreter: python3

--- a/host_vars/hosts.yml
+++ b/host_vars/hosts.yml
@@ -6,12 +6,14 @@ raspberry:
       ansible_user: pi
       ansible_password: raspberry
       ansible_python_interpreter: python3
+      hostname: raspmain1
 
     rasp2:
       ansible_host: 192.168.0.24
       ansible_user: pi
       ansible_password: raspberry
       ansible_python_interpreter: python3
+      hostname: raspcamera1
 
 raspberry_with_camera:
   hosts:

--- a/master.yml
+++ b/master.yml
@@ -1,6 +1,7 @@
 ---
 - import_playbook: playbooks/add_ssh_key_playbook.yml
 - import_playbook: playbooks/deactivate_password_playbook.yml
+- import_playbook: playbooks/set_hostname_playbook.yml
 - import_playbook: playbooks/enable_camera_playbook.yml
 - import_playbook: playbooks/common_playbook.yml
 - import_playbook: playbooks/install_pyroengine.yml

--- a/playbooks/set_hostname_playbook.yml
+++ b/playbooks/set_hostname_playbook.yml
@@ -1,0 +1,7 @@
+---
+- name: set hostname on each rpi
+  hosts: raspberry
+
+  roles:
+    - role: ../roles/hostname_setter
+      tags: hostname_setter

--- a/roles/hostname_setter/tasks/main.yml
+++ b/roles/hostname_setter/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+# tasks file for ssh_role
+- name: Wait 900 seconds for target connection to become reachable/usable
+  wait_for_connection:
+    timeout: 900
+    sleep: 5
+
+- name: change /etc/hostname
+  ansible.builtin.lineinfile:
+    path: /etc/hostname
+    regexp: "^#?raspberrypi"
+    line: "{{ hostname }}"
+  become: true
+  register: hostname_file
+  tags: hostname
+
+- name: change /etc/hosts
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: "^#?127.0.1.1"
+    line: "127.0.1.1    {{ hostname }}"
+  become: true
+  register: hosts
+  tags: hostname
+
+- name: reboot of RPI
+  reboot:
+  when: hostname_file.changed or hosts.changed
+  become: true
+  tags: dangerous

--- a/roles/ssh_role/tasks/main.yml
+++ b/roles/ssh_role/tasks/main.yml
@@ -59,11 +59,20 @@
     key: "{{ lookup('file', item.path ) }}"
   with_items: "{{ files_list.files }}"
 
-- name: set known_hosts on all rpi
+- name: set known_hosts on all rpi using id address
   ansible.builtin.known_hosts:
     name: "{{ item.value.ansible_host }}"
     state: present
     key: >
       {{ item.value.ansible_host }}
+      {{ lookup('file', '../files/ssh_ecdsa_keys/ssh_host_ecdsa_key_' + item.key + '.pub' ) }}
+  loop: "{{ hostvars | dict2items }}"
+
+- name: set known_hosts on all rpi with hostname dns
+  ansible.builtin.known_hosts:
+    name: "{{ item.value.hostname }}.local"
+    state: present
+    key: >
+      {{ item.value.hostname }}.local
       {{ lookup('file', '../files/ssh_ecdsa_keys/ssh_host_ecdsa_key_' + item.key + '.pub' ) }}
   loop: "{{ hostvars | dict2items }}"


### PR DESCRIPTION
Hi everyone, 

This PR aims at:
- adding the possibility to change the device hostname (by specifying for each device, the wanted hostname in `host_vars/hosts.yml`)
- in the folder `files/ansible_on_main_rpi` adding as `ansible_host` the `hostnamechosen.local` to allow the main rpi to communicate with its children (rpi with camera) through this dns.

This PR will stay as draft as long as we don't know if this process will work to contact using throught request the main rpi. If proven that it works (@fe51), I shall change the environment variables in `python.env` for it to work (replacing ip address with dns hostname)