### PR TITLE
Add in cron job the bash script check_internet_connection.sh

### DIFF
--- a/playbooks/add_jobs_crontab.yml
+++ b/playbooks/add_jobs_crontab.yml
@@ -10,8 +10,15 @@
         job: "/home/pi/pyro-engine/venv/bin/python3 /home/pi/pyro_engine/pyroengine/pi_utils/monitor_pi.py"
       register: crontab_output_monitor
 
+    - name: add bash script to ping google and make sure that rpi has internet / restart openVPN client if not
+      ansible.builtin.cron:
+        name: "Check internet status & restart"
+        minute: "*/15"
+        job: "bash /home/pi/pyro_engine/pyroengine/pi_utils/check_internet_connection.sh"
+      register: crontab_output_check_internet_connection
+
     - name: reboot of RPI
       reboot:
-      when: crontab_output_monitor.changed
+      when: crontab_output_monitor.changed or crontab_output_check_internet_connection.changed
       become: true
       tags: dangerous


### PR DESCRIPTION
Hello everyone, 

Quick PR corresponding to the latest changes in pyroengine (https://github.com/pyronear/pyro-engine/pull/40): the introduction of a bash script that aims to check the status of internet connection and of vpn client on the main raspberries.

The script is added in a cron job scheduled to run every 15 minutes (arbitrary number, possible to change if you think that another is more appropriate).