### PR TITLE
First versions of playbooks for updates

### DIFF
--- a/files/ansible_on_main_rpi/ansible.cfg
+++ b/files/ansible_on_main_rpi/ansible.cfg
@@ -6,3 +6,5 @@ callback_whitelist = slack
 [persistent_connection]
 connect_timeout = 60
 connect_retry_timeout = 60
+[callback_slack]
+webhook_url = my_secret_webhook_url

--- a/files/ansible_on_main_rpi/playbooks/update_rpi_camera.yml
+++ b/files/ansible_on_main_rpi/playbooks/update_rpi_camera.yml
@@ -1,0 +1,10 @@
+---
+- name: update camera rpi from main rpi
+  hosts: raspberry_with_camera
+
+  tasks:
+    - name: copy pi_utils folder from pyroengine to be executed later on hosts
+      ansible.builtin.copy:
+        src: /home/pi/pyro-engine/pyroengine/pi_utils/
+        dest: /home/pi/python_scripts
+      tags: python_scripts_camera

--- a/files/ansible_on_main_rpi/playbooks/update_rpi_main.yml
+++ b/files/ansible_on_main_rpi/playbooks/update_rpi_main.yml
@@ -1,0 +1,41 @@
+---
+- name: update main raspberries
+  hosts: localhost
+  connection: local
+
+  tasks:
+    - name: Clone pyro-engine
+      ansible.builtin.git:
+        repo: "https://github.com/pyronear/pyro-engine.git"
+        dest: /home/pi/pyro-engine
+        version: master
+      register: pyroengine_output
+      until: not pyroengine_output.failed
+      retries: 5
+      delay: 10
+      tags: pyro_engine_update
+
+    - name: update rpi main requirements from pyro-engine
+      pip:
+        requirements: /home/pi/pyro-engine/main.rpi.requirements.txt
+        virtualenv: /home/pi/pyro-engine/venv
+      register: requirements_output
+      until: not requirements_output.failed
+      retries: 5
+      delay: 10
+      tags: pyro_engine_update
+
+    - name: re-build the image docker-composer.yml and relaunch it
+      ansible.builtin.shell:
+        cmd: docker-compose up -d --build
+        chdir: /home/pi/pyro-engine/server
+      environment:
+        PORT: 8002
+      become: true
+      tags: pyro_engine_update
+
+    - name: Update text file with new hash of the pyro-engine repository
+      ansible.builtin.copy:
+        dest: /home/pi/pyroengine_version.txt
+        content: "{{ pyroengine_output.after }}"
+      tags: pyro_engine_update

--- a/playbooks/add_jobs_crontab.yml
+++ b/playbooks/add_jobs_crontab.yml
@@ -17,6 +17,14 @@
         job: "bash /home/pi/pyro_engine/pyroengine/pi_utils/check_internet_connection.sh"
       register: crontab_output_check_internet_connection
 
+    - name: add updater.py script to crontab to be launched once a day at 4:00 am
+      ansible.builtin.cron:
+        name: "Launch updater script"
+        minute: "0"
+        hour: "4"
+        job: "/home/pi/pyro-engine/venv/bin/python3 /home/pi/pyro_engine/pyroengine/pi_utils/updater.py"
+      register: crontab_output_monitor
+
     - name: reboot of RPI
       reboot:
       when: crontab_output_monitor.changed or crontab_output_check_internet_connection.changed

--- a/playbooks/install_ansible_rpi_main.yml
+++ b/playbooks/install_ansible_rpi_main.yml
@@ -25,17 +25,32 @@
         src: ../templates/vars.yml.j2
         dest: /home/pi/ansible_main/vars/main.yml
 
+    - name: modify ansible.cfg to add slack webhook_url for security
+      ansible.builtin.lineinfile:
+        path: /home/pi/ansible_main/ansible.cfg
+        regexp: "^#?webhook_url"
+        line: webhook_url = {{ SLACK_WEBHOOK_URL }}
+      tags: ansible_main
+
     - name: install ansible_main requirements
       pip:
         requirements: /home/pi/ansible_main/requirements.txt
         virtualenv: /home/pi/ansible_main/venv
         virtualenv_command: python3 -m venv
+      register: requirements_output
+      until: not requirements_output.failed
+      retries: 3
+      delay: 10
       tags: ansible_main
 
     - name: install ansible_main yaml requirements
       ansible.builtin.shell:
         cmd: /home/pi/ansible_main/venv/bin/ansible-galaxy install -r requirements.yml
         chdir: /home/pi/ansible_main
+      register: requirements_output
+      until: not requirements_output.failed
+      retries: 3
+      delay: 10
       tags: ansible_main
 
     - name: run ansible_main configure_rpi_camera playbook

--- a/playbooks/install_pyroengine.yml
+++ b/playbooks/install_pyroengine.yml
@@ -12,18 +12,17 @@
       until: not pyroengine_output.failed
       retries: 3
       delay: 10
-      tags: pyro-engine
+      tags: pyro_engine
 
-    - name: Update text file with old and new hash of the pyro-engine repository
+    - name: Update text file with new hash of the pyro-engine repository
       ansible.builtin.copy:
-        dest: /home/pi/pyroengine_versions.txt
-        content: |
-          "{{ pyroengine_output.before }}"
-          "{{ pyroengine_output.after }}"
+        dest: /home/pi/pyroengine_version.txt
+        content: "{{ pyroengine_output.after }}"
+      tags: pyro_engine
 
-    - name: install rpi master requirements from pyro-engine and create virtual env
+    - name: install rpi main requirements from pyro-engine and create virtual env
       pip:
         requirements: /home/pi/pyro-engine/main.rpi.requirements.txt
         virtualenv: /home/pi/pyro-engine/venv
         virtualenv_command: python3 -m venv
-      tags: pyro-engine
+      tags: pyro_engine


### PR DESCRIPTION
Hi everyone ! 

This PR introduces the first versions of the playbooks to update the rpi. These playbooks will be run by the main rpi using the Ansible version and sort of inner repo that it has. 

Be aware that this is only a first version and that things could be improved. However in the following weeks I'll have less time to devote to this project and hence I prefer to submit an early version of these playbooks so that you'll be able to iterate.

**For the main rpi:** 
- clone the new version of pyro-engine
- update the requirements (not optimal, maybe one should find a way to check if the requirements are already in the virtual env)
- rebuild image Docker (will probably change once docker is fixed)
- update the `pyroengine_version.txt` file with the new hash of the last commit on master of pyro-engine

(no need to updat the cron job for monitor_pi as the script will have been updated, the cron job does not change in itself). 

**For the camera rpi:**
- copy the new folder `pi_utils`
- reboot of rpi to change the makes effective (especially since we might have changed runner or monitor_pi)

In the playbook `add_jobs_crontab.yml `, I also added a cron job that will launch, once a day at 4am, the `updater.py` script (PR to come later in the week on pyroengine).

(+ minor change to ensure that Slack incoming webhook will work + renaming of a tag + some retries in case the internet connection is bad)

Later in the week, a PR of pyroengine will propose a python script to work out the flow of the update launch.

Feedback is welcome 🤗 
