### PR TITLE
Add node exporter

### DIFF
--- a/playbooks/setup_node_exporter_rpi.yml
+++ b/playbooks/setup_node_exporter_rpi.yml
@@ -3,11 +3,11 @@
   hosts: raspberry
 
   tasks:
-    - name: If armv6 architecture, download and unpack node_exporter for armv6 from prometheus 
+    - name: If armv6 architecture, download and unpack node_exporter for armv6 from prometheus
       ansible.builtin.unarchive:
         src: https://github.com/prometheus/node_exporter/releases/download/v1.1.2/node_exporter-1.1.2.linux-armv6.tar.gz
         dest: /home/pi/
-        remote_src: yes
+        remote_src: true
       become: true
       when: ansible_facts['architecture'] is search("armv6")
 
@@ -15,16 +15,16 @@
       ansible.builtin.copy:
         src: /home/pi/node_exporter-1.1.2.linux-armv6/node_exporter
         dest: /usr/local/bin/node_exporter
-        remote_src: yes
+        remote_src: true
         mode: u=rwx,g=rx,o=rx
       become: true
       when: ansible_facts['architecture'] is search("armv6")
 
-    - name: If armv7 architecture, download and unpack node_exporter for armv7 from prometheus 
+    - name: If armv7 architecture, download and unpack node_exporter for armv7 from prometheus
       ansible.builtin.unarchive:
         src: https://github.com/prometheus/node_exporter/releases/download/v1.1.2/node_exporter-1.1.2.linux-armv7.tar.gz
         dest: /home/pi/
-        remote_src: yes
+        remote_src: true
       become: true
       when: ansible_facts['architecture'] is search("armv7")
 
@@ -32,7 +32,7 @@
       ansible.builtin.copy:
         src: /home/pi/node_exporter-1.1.2.linux-armv7/node_exporter
         dest: /usr/local/bin/node_exporter
-        remote_src: yes
+        remote_src: true
         mode: u=rwx,g=rx,o=rx
       become: true
       when: ansible_facts['architecture'] is search("armv7")
@@ -40,7 +40,7 @@
     - name: create node_exporter user
       ansible.builtin.user:
         name: node_exporter
-        system: yes
+        system: true
         shell: /bin/false
       become: true
 

--- a/playbooks/setup_node_exporter_rpi.yml
+++ b/playbooks/setup_node_exporter_rpi.yml
@@ -1,0 +1,59 @@
+---
+- name: setup node exporter on rpis
+  hosts: raspberry
+
+  tasks:
+    - name: If armv6 architecture, download and unpack node_exporter for armv6 from prometheus 
+      ansible.builtin.unarchive:
+        src: https://github.com/prometheus/node_exporter/releases/download/v1.1.2/node_exporter-1.1.2.linux-armv6.tar.gz
+        dest: /home/pi/
+        remote_src: yes
+      become: true
+      when: ansible_facts['architecture'] is search("armv6")
+
+    - name: If armv6 architecture, copy node_exporter to /usr/local/bin/
+      ansible.builtin.copy:
+        src: /home/pi/node_exporter-1.1.2.linux-armv6/node_exporter
+        dest: /usr/local/bin/node_exporter
+        remote_src: yes
+        mode: u=rwx,g=rx,o=rx
+      become: true
+      when: ansible_facts['architecture'] is search("armv6")
+
+    - name: If armv7 architecture, download and unpack node_exporter for armv7 from prometheus 
+      ansible.builtin.unarchive:
+        src: https://github.com/prometheus/node_exporter/releases/download/v1.1.2/node_exporter-1.1.2.linux-armv7.tar.gz
+        dest: /home/pi/
+        remote_src: yes
+      become: true
+      when: ansible_facts['architecture'] is search("armv7")
+
+    - name: If armv7 architecture, copy node_exporter to /usr/local/bin/
+      ansible.builtin.copy:
+        src: /home/pi/node_exporter-1.1.2.linux-armv7/node_exporter
+        dest: /usr/local/bin/node_exporter
+        remote_src: yes
+        mode: u=rwx,g=rx,o=rx
+      become: true
+      when: ansible_facts['architecture'] is search("armv7")
+
+    - name: create node_exporter user
+      ansible.builtin.user:
+        name: node_exporter
+        system: yes
+        shell: /bin/false
+      become: true
+
+    - name: create node_exporter service
+      ansible.builtin.template:
+        src: ../templates/node_exporter.service.j2
+        dest: /etc/systemd/system/node_exporter.service
+      become: true
+
+    - name: start and enable service
+      ansible.builtin.systemd:
+        name: node_exporter
+        state: started
+        daemon_reload: yes
+        enabled: yes
+      become: true

--- a/playbooks/setup_node_exporter_rpi.yml
+++ b/playbooks/setup_node_exporter_rpi.yml
@@ -8,7 +8,6 @@
         src: https://github.com/prometheus/node_exporter/releases/download/v1.1.2/node_exporter-1.1.2.linux-armv6.tar.gz
         dest: /home/pi/
         remote_src: true
-      become: true
       when: ansible_facts['architecture'] is search("armv6")
 
     - name: If armv6 architecture, copy node_exporter to /usr/local/bin/
@@ -25,7 +24,6 @@
         src: https://github.com/prometheus/node_exporter/releases/download/v1.1.2/node_exporter-1.1.2.linux-armv7.tar.gz
         dest: /home/pi/
         remote_src: true
-      become: true
       when: ansible_facts['architecture'] is search("armv7")
 
     - name: If armv7 architecture, copy node_exporter to /usr/local/bin/

--- a/templates/node_exporter.service.j2
+++ b/templates/node_exporter.service.j2
@@ -1,0 +1,16 @@
+[Unit]
+Description=Node Exporter
+After=network.target
+
+[Service]
+# User and group used to run this service.
+User=node_exporter
+Group=node_exporter
+Type=simple
+
+# Some node exporter collectors are enabled by default.
+# Please see https://github.com/prometheus/node_exporter#collectors for details
+ExecStart=/usr/local/bin/node_exporter
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR aims at adding playbook to set up a node exporter on each rpis.

Hence, after running the playbook, metrics of pis are available on port 9100 via their hostname or ip (ex:  http://pimain.local:9100/metrics or http://192.168.1.64:9100/metrics)


- Tasks in the playbook :
  - According to rpi architecture, download an copy to `/usr/local/bin/` the relevant version of the [prometheus node exporter](https://github.com/prometheus/node_exporter/releases)
  - Create node_exporter user
  - Create node_exporter service from template
  - Start and enable the service



- In the future, gathered machine metrics could be updated (see https://github.com/prometheus/node_exporter#collectors or http://manpages.ubuntu.com/manpages/groovy/man1/prometheus-node-exporter.1.html for details ). To date, metrics we wanted are available :
  - <u>Temperature</u> with `node_thermal_zone_temp`
  - <u>RAM</u> with `node_memory_MemAvailable_bytes` (many are available)
  - <u>Cpu</u>, a lot of metrics are avaialble, will have to choose relevant ones when building dashboards


A another PR setting up nginx (allowing to requests on 9100 to any pi metrics from bastion) will come up soon. 

Feedbacks are welcome (Especially, condition about architecture, implementation works, but that might be a cleaner way to do it)

