### PR TITLE
Add nginx reverse proxy rpi main

### DIFF
--- a/playbooks/setup_reverse_proxy_rpi_main.yml
+++ b/playbooks/setup_reverse_proxy_rpi_main.yml
@@ -1,0 +1,34 @@
+---
+- name: setup nginx reverse proxy in order to let pi camera metrics available via VPN
+  hosts: raspberry_mains
+
+    tasks:
+    - name: sudo apt update
+      ansible.builtin.debug:
+        msg: "useless here car update done in common playbook"
+
+    - name: install nginx
+      apt:
+        name:
+          - nginx
+        state: latest
+        update_cache: true
+      become: true
+
+    - name: create nginx.conf from template 
+      ansible.builtin.template:
+        src: ../templates/nginx.conf.j2
+        dest: /etc/nginx/nginx.conf
+      become: true
+
+    - name: sudo /etc/init.d/nginx start
+      ansible.builtin.debug:
+        msg: "kikou"
+
+    - name: start and enable service. A TESTER
+      ansible.builtin.systemd:
+        name: nginx
+        state: started
+        daemon_reload: yes
+        enabled: yes
+      become: true

--- a/playbooks/setup_reverse_proxy_rpi_main.yml
+++ b/playbooks/setup_reverse_proxy_rpi_main.yml
@@ -10,25 +10,25 @@
         update_cache: true
       become: true
 
-    - name: create nginx.conf from template 
+    - name: create nginx.conf from template
       ansible.builtin.template:
         src: ../templates/nginx.conf.j2
         dest: /etc/nginx/nginx.conf
       become: true
 
-    - name: add buffer.conf from template 
+    - name: add buffer.conf from template
       ansible.builtin.template:
         src: ../templates/buffer.conf.j2
         dest: /etc/nginx/buffer.conf
       become: true
 
-    - name: add common_location.conf from template 
+    - name: add common_location.conf from template
       ansible.builtin.template:
         src: ../templates/common_location.conf.j2
         dest: /etc/nginx/common_location.conf
       become: true
 
-    - name: add common.conf from template 
+    - name: add common.conf from template
       ansible.builtin.template:
         src: ../templates/common.conf.j2
         dest: /etc/nginx/common.conf

--- a/playbooks/setup_reverse_proxy_rpi_main.yml
+++ b/playbooks/setup_reverse_proxy_rpi_main.yml
@@ -34,7 +34,7 @@
         dest: /etc/nginx/common.conf
       become: true
 
-    - name: start and enable service. A TESTER
+    - name: start and enable service
       ansible.builtin.systemd:
         name: nginx
         state: started

--- a/playbooks/setup_reverse_proxy_rpi_main.yml
+++ b/playbooks/setup_reverse_proxy_rpi_main.yml
@@ -2,15 +2,10 @@
 - name: setup nginx reverse proxy in order to let pi camera metrics available via VPN
   hosts: raspberry_mains
 
-    tasks:
-    - name: sudo apt update
-      ansible.builtin.debug:
-        msg: "useless here car update done in common playbook"
-
+  tasks:
     - name: install nginx
       apt:
-        name:
-          - nginx
+        name: nginx
         state: latest
         update_cache: true
       become: true
@@ -21,9 +16,23 @@
         dest: /etc/nginx/nginx.conf
       become: true
 
-    - name: sudo /etc/init.d/nginx start
-      ansible.builtin.debug:
-        msg: "kikou"
+    - name: add buffer.conf from template 
+      ansible.builtin.template:
+        src: ../templates/buffer.conf.j2
+        dest: /etc/nginx/buffer.conf
+      become: true
+
+    - name: add common_location.conf from template 
+      ansible.builtin.template:
+        src: ../templates/common_location.conf.j2
+        dest: /etc/nginx/common_location.conf
+      become: true
+
+    - name: add common.conf from template 
+      ansible.builtin.template:
+        src: ../templates/common.conf.j2
+        dest: /etc/nginx/common.conf
+      become: true
 
     - name: start and enable service. A TESTER
       ansible.builtin.systemd:

--- a/templates/buffer.conf.j2
+++ b/templates/buffer.conf.j2
@@ -1,0 +1,4 @@
+client_body_buffer_size  1k;
+client_header_buffer_size 1k;
+client_max_body_size 1k;
+large_client_header_buffers 2 1k;

--- a/templates/common.conf.j2
+++ b/templates/common.conf.j2
@@ -1,0 +1,4 @@
+add_header Strict-Transport-Security    "max-age=31536000; includeSubDomains" always;
+add_header X-Frame-Options              SAMEORIGIN;
+add_header X-Content-Type-Options       nosniff;
+add_header X-XSS-Protection             "1; mode=block";

--- a/templates/common_location.conf.j2
+++ b/templates/common_location.conf.j2
@@ -1,0 +1,6 @@
+proxy_set_header    X-Real-IP           $remote_addr;
+proxy_set_header    X-Forwarded-For     $proxy_add_x_forwarded_for;
+proxy_set_header    X-Forwarded-Proto   $scheme;
+proxy_set_header    Host                $host;
+proxy_set_header    X-Forwarded-Host    $host;
+proxy_set_header    X-Forwarded-Port    $server_port;

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -1,0 +1,74 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+    worker_connections 1024;
+}
+
+http {
+
+upstream mainpi {
+    least_conn;
+    server localhost:9100;
+}
+
+upstream server_api {
+    least_conn;
+    server localhost:8010;
+}
+
+#upstream picam1 {
+#    least_conn;
+#    server picam.local:9100;
+#}
+#upstream picam1 {
+#    least_conn;
+#    server 192.168.1.64:9100;
+#}
+
+{% for host in groups['raspberry_with_camera'] %}
+upstream {{ hostvars[host]['hostname'] }}_a {
+    least_conn;
+    server {{ hostvars[host]['hostname'] }}.local:9100;
+    server 192.168.1.64:9100;
+} 
+{% endfor %}
+
+
+
+server {
+
+  listen 80;
+  include /etc/nginx/common.conf;
+  include /etc/nginx/buffer.conf;
+
+
+  location /pi_central_metrics {
+    proxy_pass http://mainpi/metrics;
+    include /etc/nginx/common_location.conf;
+  }
+
+  location / {
+    proxy_pass http://server_api;
+    include /etc/nginx/common_location.conf;
+   }
+
+ # location /picam1_metrics {
+ #   proxy_pass http://picam1/metrics;
+ #   include /etc/nginx/common_location.conf;
+ # }
+
+  {% for host in groups['raspberry_with_camera'] %}
+    location /{{ hostvars[host]['hostname'] }}_metrics {
+        proxy_pass http://{{ hostvars[host]['hostname'] }}_a/metrics;
+        include /etc/nginx/common_location.conf;
+    } 
+    {% endfor %}
+
+  }
+
+}
+
+

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -19,23 +19,12 @@ upstream server_api {
     server localhost:8010;
 }
 
-#upstream picam1 {
-#    least_conn;
-#    server picam.local:9100;
-#}
-#upstream picam1 {
-#    least_conn;
-#    server 192.168.1.64:9100;
-#}
-
 {% for host in groups['raspberry_with_camera'] %}
 upstream {{ hostvars[host]['hostname'] }}_a {
     least_conn;
     server {{ hostvars[host]['hostname'] }}.local:9100;
-    server 192.168.1.64:9100;
 } 
 {% endfor %}
-
 
 
 server {
@@ -65,7 +54,7 @@ server {
         proxy_pass http://{{ hostvars[host]['hostname'] }}_a/metrics;
         include /etc/nginx/common_location.conf;
     } 
-    {% endfor %}
+   {% endfor %}
 
   }
 

--- a/templates/nginx.conf.j2
+++ b/templates/nginx.conf.j2
@@ -16,7 +16,7 @@ upstream mainpi {
 
 upstream server_api {
     least_conn;
-    server localhost:8010;
+    server localhost:8002;
 }
 
 {% for host in groups['raspberry_with_camera'] %}
@@ -43,11 +43,6 @@ server {
     proxy_pass http://server_api;
     include /etc/nginx/common_location.conf;
    }
-
- # location /picam1_metrics {
- #   proxy_pass http://picam1/metrics;
- #   include /etc/nginx/common_location.conf;
- # }
 
   {% for host in groups['raspberry_with_camera'] %}
     location /{{ hostvars[host]['hostname'] }}_metrics {


### PR DESCRIPTION
This (draft) PR aims at adding an **nginx reverse proxy** to the main pi. 
Hence, pi camera logs from node exporter will be available once connected to the vpn

As long as it relies on hostnames, the PR need to be merged after #16 (adding role to set hostnames)

- **Issue**: If an host is not available, nginx does not start. @ThibaultDac, do you have any idea for a workaround? 

- **Question**: Also, eventually, in what extend it is necessary/useful to add the redirection from the webserver ?


Finally, I have assumed that the port from the webserver is 8002, but it might be better to get if from conf file. 

Thanks for the help and feedbacks. 